### PR TITLE
Added math mode for Pagic

### DIFF
--- a/src/plugins/md.tsx
+++ b/src/plugins/md.tsx
@@ -4,6 +4,7 @@ import markdownItAnchor from '../vendors/markdown-it-anchor/index.js';
 import markdownitTocDoneRight from '../vendors/markdown-it-toc-done-right/index.js';
 import markdownitReplaceLink from '../vendors/markdown-it-replace-link/index.js';
 import markdownitHighlightLines from '../vendors/markdown-it-highlight-lines/index.js';
+import markdownItKatex from '../vendors/markdown-it-katex/index.js';
 
 import Prism from '../vendors/prism/mod.ts';
 import { replaceLink, getGitLog } from '../utils/mod.ts';
@@ -67,7 +68,8 @@ const md: PagicPlugin = {
         }
       })
       .use(markdownitReplaceLink)
-      .use(markdownitHighlightLines);
+      .use(markdownitHighlightLines)
+      .use(markdownItKatex);
 
     for (const pagePath of pagic.pagePaths.filter((pagePath) => pagePath.endsWith('.md'))) {
       const pageProps = pagic.pagePropsMap[pagePath];

--- a/src/plugins/md.tsx
+++ b/src/plugins/md.tsx
@@ -69,7 +69,9 @@ const md: PagicPlugin = {
       })
       .use(markdownitReplaceLink)
       .use(markdownitHighlightLines)
-      .use(markdownItKatex);
+      .use(markdownItKatex, {
+        output: 'mathml'
+      });
 
     for (const pagePath of pagic.pagePaths.filter((pagePath) => pagePath.endsWith('.md'))) {
       const pageProps = pagic.pagePropsMap[pagePath];

--- a/src/vendors/markdown-it-katex/index.js
+++ b/src/vendors/markdown-it-katex/index.js
@@ -1,0 +1,202 @@
+/* Process inline math */
+/*
+All credit goes to waylonflinn (www.github.com/waylonflinn). 
+
+Like markdown-it-simplemath, this is a stripped down, simplified version of:
+https://github.com/runarberg/markdown-it-math
+It differs in that it takes (a subset of) LaTeX as input and relies on KaTeX
+for rendering output.
+*/
+
+/*jslint node: true */
+'use strict';
+
+import katex from 'https://cdn.jsdelivr.net/npm/katex@0.12.0/dist/katex.mjs';
+
+// Test if potential opening or closing delimieter
+// Assumes that there is a "$" at state.src[pos]
+function isValidDelim(state, pos) {
+    var prevChar, nextChar,
+        max = state.posMax,
+        can_open = true,
+        can_close = true;
+
+    prevChar = pos > 0 ? state.src.charCodeAt(pos - 1) : -1;
+    nextChar = pos + 1 <= max ? state.src.charCodeAt(pos + 1) : -1;
+
+    // Check non-whitespace conditions for opening and closing, and
+    // check that closing delimeter isn't followed by a number
+    if (prevChar === 0x20/* " " */ || prevChar === 0x09/* \t */ ||
+            (nextChar >= 0x30/* "0" */ && nextChar <= 0x39/* "9" */)) {
+        can_close = false;
+    }
+    if (nextChar === 0x20/* " " */ || nextChar === 0x09/* \t */) {
+        can_open = false;
+    }
+
+    return {
+        can_open: can_open,
+        can_close: can_close
+    };
+}
+
+function math_inline(state, silent) {
+    var start, match, token, res, pos, esc_count;
+
+    if (state.src[state.pos] !== "$") { return false; }
+
+    res = isValidDelim(state, state.pos);
+    if (!res.can_open) {
+        if (!silent) { state.pending += "$"; }
+        state.pos += 1;
+        return true;
+    }
+
+    // First check for and bypass all properly escaped delimieters
+    // This loop will assume that the first leading backtick can not
+    // be the first character in state.src, which is known since
+    // we have found an opening delimieter already.
+    start = state.pos + 1;
+    match = start;
+    while ( (match = state.src.indexOf("$", match)) !== -1) {
+        // Found potential $, look for escapes, pos will point to
+        // first non escape when complete
+        pos = match - 1;
+        while (state.src[pos] === "\\") { pos -= 1; }
+
+        // Even number of escapes, potential closing delimiter found
+        if ( ((match - pos) % 2) == 1 ) { break; }
+        match += 1;
+    }
+
+    // No closing delimter found.  Consume $ and continue.
+    if (match === -1) {
+        if (!silent) { state.pending += "$"; }
+        state.pos = start;
+        return true;
+    }
+
+    // Check if we have empty content, ie: $$.  Do not parse.
+    if (match - start === 0) {
+        if (!silent) { state.pending += "$$"; }
+        state.pos = start + 1;
+        return true;
+    }
+
+    // Check for valid closing delimiter
+    res = isValidDelim(state, match);
+    if (!res.can_close) {
+        if (!silent) { state.pending += "$"; }
+        state.pos = start;
+        return true;
+    }
+
+    if (!silent) {
+        token         = state.push('math_inline', 'math', 0);
+        token.markup  = "$";
+        token.content = state.src.slice(start, match);
+    }
+
+    state.pos = match + 1;
+    return true;
+}
+
+function math_block(state, start, end, silent){
+    var firstLine, lastLine, next, lastPos, found = false, token,
+        pos = state.bMarks[start] + state.tShift[start],
+        max = state.eMarks[start]
+
+    if(pos + 2 > max){ return false; }
+    if(state.src.slice(pos,pos+2)!=='$$'){ return false; }
+
+    pos += 2;
+    firstLine = state.src.slice(pos,max);
+
+    if(silent){ return true; }
+    if(firstLine.trim().slice(-2)==='$$'){
+        // Single line expression
+        firstLine = firstLine.trim().slice(0, -2);
+        found = true;
+    }
+
+    for(next = start; !found; ){
+
+        next++;
+
+        if(next >= end){ break; }
+
+        pos = state.bMarks[next]+state.tShift[next];
+        max = state.eMarks[next];
+
+        if(pos < max && state.tShift[next] < state.blkIndent){
+            // non-empty line with negative indent should stop the list:
+            break;
+        }
+
+        if(state.src.slice(pos,max).trim().slice(-2)==='$$'){
+            lastPos = state.src.slice(0,max).lastIndexOf('$$');
+            lastLine = state.src.slice(pos,lastPos);
+            found = true;
+        }
+
+    }
+
+    state.line = next + 1;
+
+    token = state.push('math_block', 'math', 0);
+    token.block = true;
+    token.content = (firstLine && firstLine.trim() ? firstLine + '\n' : '')
+    + state.getLines(start + 1, next, state.tShift[start], true)
+    + (lastLine && lastLine.trim() ? lastLine : '');
+    token.map = [ start, state.line ];
+    token.markup = '$$';
+    return true;
+}
+
+function math_plugin(md, options) {
+    // Default options
+
+    options = options || {};
+
+    // set KaTeX as the renderer for markdown-it-simplemath
+    var katexInline = function(latex){
+        options.displayMode = false;
+        try{
+            return katex.renderToString(latex, options);
+        }
+        catch(error){
+            if(options.throwOnError){ console.log(error); }
+            return latex;
+        }
+    };
+
+    var inlineRenderer = function(tokens, idx){
+        return katexInline(tokens[idx].content);
+    };
+
+    var katexBlock = function(latex){
+        options.displayMode = true;
+        // html output is buggy
+        options.output = 'mathml';
+        try{
+            return "<p>" + katex.renderToString(latex, options) + "</p>";
+        }
+        catch(error){
+            if(options.throwOnError){ console.log(error); }
+            return latex;
+        }
+    }
+
+    var blockRenderer = function(tokens, idx){
+        return  katexBlock(tokens[idx].content) + '\n';
+    }
+
+    md.inline.ruler.after('escape', 'math_inline', math_inline);
+    md.block.ruler.after('blockquote', 'math_block', math_block, {
+        alt: [ 'paragraph', 'reference', 'blockquote', 'list' ]
+    });
+    md.renderer.rules.math_inline = inlineRenderer;
+    md.renderer.rules.math_block = blockRenderer;
+};
+
+export default math_plugin

--- a/src/vendors/markdown-it-katex/index.js
+++ b/src/vendors/markdown-it-katex/index.js
@@ -176,8 +176,6 @@ function math_plugin(md, options) {
 
     var katexBlock = function(latex){
         options.displayMode = true;
-        // html output is buggy
-        options.output = 'mathml';
         try{
             return "<p>" + katex.renderToString(latex, options) + "</p>";
         }


### PR DESCRIPTION
People using Pagic can now write LaTeX-style math,
either inline or block. For inline, one can simply
write their math between two single dollar signs and
for block-style math, they can write it between two
pairs of dollar signs.