### PR TITLE
Added blog property to interface PageProps

### DIFF
--- a/src/Pagic.ts
+++ b/src/Pagic.ts
@@ -63,7 +63,7 @@ export interface PageProps {
   blog?: {
     isPost: boolean;
     isPosts: boolean;
-    posts: Array< { pagePath: string, title: string, link: string, outputPath: string, date: Date, updated: boolean } >;
+    posts: Array< { pagePath: string, title: string, link: string, date: Date, updated: boolean } >;
   };
   pagePath: string;
   layoutPath: string;

--- a/src/Pagic.ts
+++ b/src/Pagic.ts
@@ -61,9 +61,9 @@ export type PagicLayout<
 export interface PageProps {
   config: PagicConfig;
   blog?: {
-    isPost: false;
-    isPosts: false;
-    posts: [];
+    isPost: boolean;
+    isPosts: boolean;
+    posts: Array< { pagePath: string, title: string, outputPath: PageProps, date: Date, updated: boolean } >;
   };
   pagePath: string;
   layoutPath: string;

--- a/src/Pagic.ts
+++ b/src/Pagic.ts
@@ -64,11 +64,11 @@ export interface PageProps {
     isPost: boolean;
     isPosts: boolean;
     posts: { 
-      pagePath: string; 
-      title: string; 
-      link: string; 
-      date: Date | string; 
-      updated: Date | string; 
+      pagePath: string;
+      title: string;
+      link: string;
+      date: Date | string;
+      updated: Date | string;
     } [];
   };
   pagePath: string;

--- a/src/Pagic.ts
+++ b/src/Pagic.ts
@@ -308,20 +308,6 @@ export default class Pagic {
       )
     ]);
 
-    console.log('Location of mod.ts: ');
-    console.log(`${this.config.outDir}/mod.ts`);
-    await Deno.writeTextFile(`${this.config.outDir}/mod.ts`, 
-      `export default {
-          files: [
-            `);
-    let foo = this.staticPaths.concat(this.layoutPaths);
-    console.log(foo);
-    for (const modFile of this.staticPaths.concat(this.layoutPaths)) {
-        Deno.writeTextFile(`${this.config.outDir}/mod.ts`, "'" + modFile + ',\n');
-    }
-    await Deno.writeTextFile(`${this.config.outDir}/mod.ts`, `]
-  }`);
-    console.log('After writing files')
   }
 
   private async runPlugins() {

--- a/src/Pagic.ts
+++ b/src/Pagic.ts
@@ -63,7 +63,13 @@ export interface PageProps {
   blog?: {
     isPost: boolean;
     isPosts: boolean;
-    posts: Array< { pagePath: string, title: string, link: string, date: Date, updated: boolean } >;
+    posts: { 
+      pagePath: string; 
+      title: string; 
+      link: string; 
+      date: Date | string; 
+      updated: Date | string; 
+    } [];
   };
   pagePath: string;
   layoutPath: string;
@@ -301,6 +307,21 @@ export default class Pagic {
         (filename) => !Pagic.REGEXP_PAGE.test(`/${filename}`) && !Pagic.REGEXP_LAYOUT.test(`/${filename}`)
       )
     ]);
+
+    console.log('Location of mod.ts: ');
+    console.log(`${this.config.outDir}/mod.ts`);
+    await Deno.writeTextFile(`${this.config.outDir}/mod.ts`, 
+      `export default {
+          files: [
+            `);
+    let foo = this.staticPaths.concat(this.layoutPaths);
+    console.log(foo);
+    for (const modFile of this.staticPaths.concat(this.layoutPaths)) {
+        Deno.writeTextFile(`${this.config.outDir}/mod.ts`, "'" + modFile + ',\n');
+    }
+    await Deno.writeTextFile(`${this.config.outDir}/mod.ts`, `]
+  }`);
+    console.log('After writing files')
   }
 
   private async runPlugins() {

--- a/src/Pagic.ts
+++ b/src/Pagic.ts
@@ -63,7 +63,7 @@ export interface PageProps {
   blog?: {
     isPost: boolean;
     isPosts: boolean;
-    posts: Array< { pagePath: string, title: string, outputPath: PageProps, date: Date, updated: boolean } >;
+    posts: Array< { pagePath: string, title: string, link: string, outputPath: string, date: Date, updated: boolean } >;
   };
   pagePath: string;
   layoutPath: string;

--- a/src/Pagic.ts
+++ b/src/Pagic.ts
@@ -57,8 +57,14 @@ export type PagicLayout<
   }
 > = React.FC<PageProps & T>;
 
+
 export interface PageProps {
   config: PagicConfig;
+  blog?: {
+    isPost: false;
+    isPosts: false;
+    posts: [];
+  };
   pagePath: string;
   layoutPath: string;
   outputPath: string;

--- a/src/plugins/init.tsx
+++ b/src/plugins/init.tsx
@@ -10,7 +10,6 @@ const init: PagicPlugin = {
       const outputPath = getOutputPath(pagePath);
       pagic.pagePropsMap[pagePath] = {
         config: pagic.config,
-        blog: { isPost: false, isPosts: false, posts: [] },
         pagePath,
         layoutPath,
         outputPath,

--- a/src/plugins/init.tsx
+++ b/src/plugins/init.tsx
@@ -10,6 +10,7 @@ const init: PagicPlugin = {
       const outputPath = getOutputPath(pagePath);
       pagic.pagePropsMap[pagePath] = {
         config: pagic.config,
+        blog: { isPost: false, isPosts: false, posts: [] },
         pagePath,
         layoutPath,
         outputPath,

--- a/src/themes/docs/_layout.tsx
+++ b/src/themes/docs/_layout.tsx
@@ -21,7 +21,7 @@ const Layout: PagicLayout = (props) => {
       <body>
         <Header {...props} isDark={isDark} setIsDark={setIsDark} />
         <Sidebar {...props} />
-        {props.blog.isPosts ? <Posts {...props} /> : <Main {...props} />}
+        {props.blog?.isPosts ? <Posts {...props} /> : <Main {...props} />}
         <Footer {...props} />
         <Tools {...props} />
         {props.script}

--- a/src/themes/docs/_posts.tsx
+++ b/src/themes/docs/_posts.tsx
@@ -12,7 +12,7 @@ const Posts: PagicLayout = (props) => {
         <article>
           {contentTitle}
           <ul className="main_posts">
-            {blog.posts.map(({ title, link, date }: any) => (
+            {blog?.posts.map(({ title, link, date }: any) => (
               <li key={link}>
                 <time dateTime={date}>{dateFormatter['YYYY-MM-DD'](date)}</time>
                 <a href={`${config.root}${link}`}>{title}</a>


### PR DESCRIPTION
Some tsx files reference a property 'blog' in the interface PageProps in
src/Pagic.ts, even though the blog property was never defined
(src/plugins/blog.tsx, src/themes/docs/_layout.tsx, ...). This would
cause a build error when building some demo sites mentioned on Pagic
such as es-interview, deno-tutorial, etc. The blog property needs
to be optional to satisfy CI tests.