### PR TITLE
chore: Use Deno v1.9.2 in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,7 @@ jobs:
       - name: Setup deno
         uses: denolib/setup-deno@v2
         with:
-          deno-version: v1.7.0
+          deno-version: v1.9.2
 
       - name: Run tests
         run: deno test --unstable --allow-read --allow-write --allow-net --allow-run src


### PR DESCRIPTION
At the commit 1ebfe5a7f69d057c71960647859b6fa83b3246d7, Deno has been updated to v1.9.2. To follow it, this PR also updates Deno used in CI to v1.9.2. :slightly_smiling_face: 