### PR TITLE
feat: add definePagicOptions methods for improve ux

### DIFF
--- a/src/Pagic.ts
+++ b/src/Pagic.ts
@@ -388,3 +388,7 @@ export default class Pagic {
     }
   }
 }
+
+export function defindPagicOptions(options:Partial<PagicConfig> ={}) {
+  return options
+}

--- a/src/Pagic.ts
+++ b/src/Pagic.ts
@@ -389,6 +389,6 @@ export default class Pagic {
   }
 }
 
-export function defindPagicOptions(options:Partial<PagicConfig> ={}) {
+export function definePagicOptions(options:Partial<PagicConfig> ={}) {
   return options
 }


### PR DESCRIPTION
use a definePagicOptions methods instead of export define plain object that can improve ux

origin pagic.config.ts
```ts
export default {
 // no prompt
  srcDir: "docs/"
}
```

now
```
import { definePagicOptions } from 'https://deno.land/x/pagic/mod.ts';
export default definePagicOptions({
  // got prompt!
 srcDir: "docs/"
});
```