### PR TITLE
Markdown katex macro

### DIFF
--- a/src/Pagic.ts
+++ b/src/Pagic.ts
@@ -59,6 +59,7 @@ export interface PagicConfig {
     anchorLevel?: (1 | 2 | 3 | 4 | 5 | 6)[];
     tocEnabled?: boolean;
     tocLevel?: (1 | 2 | 3 | 4 | 5 | 6)[];
+    katexMacros?: Record<string, string>;
   };
   ga?: GaProps;
   gitalk?: GitalkProps;

--- a/src/plugins/md.tsx
+++ b/src/plugins/md.tsx
@@ -88,7 +88,9 @@ const md: PagicPlugin = {
        * Use markdown-it-title to get the title of the page
        * https://github.com/valeriangalliat/markdown-it-title
        */
-      const env: any = {};
+      const env: any = {
+        katexMacros: Object.assign({}, pagic.config.md?.katexMacros)
+      };
       const contentHTML = mdRenderer
         .render(content, env)
         .replace(/<table[\s\S]*?<\/table>/g, '<div class="table_wrapper">$&</div>')

--- a/src/vendors/markdown-it-katex/index.js
+++ b/src/vendors/markdown-it-katex/index.js
@@ -159,8 +159,7 @@ function math_plugin(md, options) {
     options = options || {};
 
     // set KaTeX as the renderer for markdown-it-simplemath
-    var katexInline = function(latex){
-        options.displayMode = false;
+    var render = function(latex){
         try{
             return katex.renderToString(latex, options);
         }
@@ -170,23 +169,16 @@ function math_plugin(md, options) {
         }
     };
 
-    var inlineRenderer = function(tokens, idx){
-        return katexInline(tokens[idx].content);
+    var inlineRenderer = function(tokens, idx, _, env){
+        options.macros = env.katexMacros;
+        options.displayMode = false;
+        return render(tokens[idx].content);
     };
 
-    var katexBlock = function(latex){
+    var blockRenderer = function(tokens, idx, _, env){
+        options.macros = env.katexMacros;
         options.displayMode = true;
-        try{
-            return "<p>" + katex.renderToString(latex, options) + "</p>";
-        }
-        catch(error){
-            if(options.throwOnError){ console.log(error); }
-            return latex;
-        }
-    }
-
-    var blockRenderer = function(tokens, idx){
-        return  katexBlock(tokens[idx].content) + '\n';
+        return '<p>' + render(tokens[idx].content) + '</p>\n';
     }
 
     md.inline.ruler.after('escape', 'math_inline', math_inline);


### PR DESCRIPTION
This patch enables users to define page level and global katex macro, so that they don't have to type long but frequent math expression over and over again.

Example:

Global macros in `pagic.config.ts`
```
export default {
  md: {
    katexMacros: {
      "\\Z": "\\mathbb{Z}",
      "\\Null": "\\mathit{Null}",
      "\\cycl": "\\langle #1 \\rangle"
    },
  },
};
```

Some additional macros in `index.md`
```
$$
\gdef \greetings#1{\text{Welcome to my site, #1!}}
\gdef \degree{^\circ}
$$

$$\greetings{World}$$

A $90 \degree$ counter-clockwise rotation.

The null space of a matrix is $\Null(A) = \{\vec{x}\in \R^n : A\vec{x}=\vec{0}\}$

A cyclic subgroup is $\cycl{g} = \{ g^k | k \in \Z \}$.
```

result:
<img width="786" alt="Screen Shot 2021-08-10 at 5 43 07 PM" src="https://user-images.githubusercontent.com/19396458/128939064-6e54a9df-a1b1-43c3-bf9a-2f103af40ee6.png">


