### PR TITLE
docs: update deployment

### DIFF
--- a/pagic.org/docs/deployment.md
+++ b/pagic.org/docs/deployment.md
@@ -18,14 +18,14 @@ on:
 
 jobs:
   build-and-deploy:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - name: Setup deno
-        uses: denolib/setup-deno@v2
+        uses: denoland/setup-deno@v1
         with:
-          deno-version: v1.7.0
+          deno-version: vx.x.x
 
       - name: Build gh-pages
         run: |
@@ -40,6 +40,8 @@ jobs:
           publish_dir: ./dist
           cname: ts.xcatliu.com
 ```
+
+Be sure Actions read and write permissions are enabled, otherwise the build will fail, To open it, Go Settings - Actions - General - Workflow permissions Check Read and write permissions and save.
 
 Be sure to replace `ts.xcatliu.com` in the last line with your own domain.
 

--- a/pagic.org/zh-CN/docs/deployment.md
+++ b/pagic.org/zh-CN/docs/deployment.md
@@ -18,14 +18,14 @@ on:
 
 jobs:
   build-and-deploy:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - name: Setup deno
-        uses: denolib/setup-deno@v2
+        uses: denoland/setup-deno@v1
         with:
-          deno-version: v1.7.0
+          deno-version: vx.x.x
 
       - name: Build gh-pages
         run: |
@@ -40,6 +40,7 @@ jobs:
           publish_dir: ./dist
           cname: ts.xcatliu.com
 ```
+请确认已经开启了 Actions 的读写权限，如果没有开启会导致构建失败，要开启它，请到 Settings - Actions - General - Workflow permissions 找到 Read and write permissions 选择并保存。
 
 注意替换掉最后一行的 `ts.xcatliu.com` 为你自己的域名。
 


### PR DESCRIPTION
Because Github Actions now don't have write permissions by default, which can cause builds to fail, it needs to be brought up in the documentation, and also denolib has stopped supporting it, and it throws a warning during builds.

- use latest ubuntu
- update actions/checkout3
- denolib is EOD now use denoland
- Now actions default has no permission to write mention it on dosc